### PR TITLE
feat: self-documenting make.sh

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
+if [ -z "${XOVI_HOME}" ]; then
+  echo "Environment variable XOVI_HOME is empty or not set."
+  exit 1
+fi
+
+if [ ! -e "${HOME}/Tools/remarkable-toolchain/environment-setup-cortexa53-crypto-remarkable-linux" ]; then
+  echo "The remarkable toolchain should be accessible via '~/Tools/remarkable-toolchain'."
+fi
+
+source ~/Tools/remarkable-toolchain/environment-setup-cortexa53-crypto-remarkable-linux
 python3 $XOVI_HOME/util/xovigen.py -o xoviout literm.xovi
 qmake6 .
 make -j`nproc`
-


### PR DESCRIPTION
This tells a user all that they should need to know in order to set this up

It solves two problems:

* Not setting XOVI_HOME
* Not having the correct and consistent $HOME/Tools/remarkable-toolchain

It does not attempt to work-around by git cloning which I did see in the extensions repo.